### PR TITLE
feat(hero): derive ambient glow from active card surface

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { ArrowRight, ArrowUpRight, ChevronLeft, ChevronRight, Code2 } from 'lucide-react';
 import { projects as featuredProjects } from '../data/projects';
 import { ProjectCardStatic } from './ProjectCardStatic';
+import { toGlow } from '../lib/color';
 
 export const Hero: React.FC = () => {
   const { t } = useTranslation();
@@ -18,6 +19,15 @@ export const Hero: React.FC = () => {
 
   const currentProject = featuredProjects[currentProjectIndex];
   const totalProjects = featuredProjects.length;
+
+  // The hero ambient light echoes the active card's own surface gradient, so the
+  // glow always feels like it radiates from the card+logo on screen. surfaceTo
+  // (the card's luminous end) lights the area behind the card; surfaceFrom (its
+  // shadow end) tints the headline side. Both are normalized to stay vivid.
+  const surfaceTo = currentProject.surfaceTo ?? currentProject.color;
+  const surfaceFrom = currentProject.surfaceFrom ?? currentProject.color;
+  const glowMain = toGlow(surfaceTo, currentProject.color);
+  const glowAccent = toGlow(surfaceFrom, surfaceTo);
 
   const goToPreviousProject = () => {
     setCurrentProjectIndex((prev) => (prev - 1 + totalProjects) % totalProjects);
@@ -37,13 +47,13 @@ export const Hero: React.FC = () => {
         <div
           className="absolute inset-0 transition-opacity duration-700"
           style={{
-            background: `radial-gradient(ellipse 80% 70% at 70% 40%, ${currentProject.color}50 0%, transparent 70%)`
+            background: `radial-gradient(ellipse 80% 70% at 70% 40%, ${glowMain}50 0%, transparent 70%)`
           }}
         />
         <div
           className="absolute inset-0 transition-opacity duration-700"
           style={{
-            background: `radial-gradient(circle at 22% 24%, ${currentProject.color}20 0%, transparent 36%)`
+            background: `radial-gradient(circle at 22% 24%, ${glowAccent}20 0%, transparent 36%)`
           }}
         />
       </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -43,17 +43,27 @@ export const Hero: React.FC = () => {
 
   return (
     <section className="relative w-full px-6 pt-12 pb-24 min-h-[calc(100vh-4rem)] flex items-center">
-      <div className="absolute inset-0 pointer-events-none overflow-hidden">
+      <div
+        className="hero-ambient absolute inset-0 pointer-events-none overflow-hidden"
+        style={
+          {
+            '--hero-glow-main': `${glowMain}50`,
+            '--hero-glow-accent': `${glowAccent}20`
+          } as React.CSSProperties
+        }
+      >
         <div
-          className="absolute inset-0 transition-opacity duration-700"
+          className="absolute inset-0"
           style={{
-            background: `radial-gradient(ellipse 80% 70% at 70% 40%, ${glowMain}50 0%, transparent 70%)`
+            background:
+              'radial-gradient(ellipse 80% 70% at 70% 40%, var(--hero-glow-main) 0%, transparent 70%)'
           }}
         />
         <div
-          className="absolute inset-0 transition-opacity duration-700"
+          className="absolute inset-0"
           style={{
-            background: `radial-gradient(circle at 22% 24%, ${glowAccent}20 0%, transparent 36%)`
+            background:
+              'radial-gradient(circle at 22% 24%, var(--hero-glow-accent) 0%, transparent 36%)'
           }}
         />
       </div>

--- a/src/components/ProjectCardStatic.tsx
+++ b/src/components/ProjectCardStatic.tsx
@@ -10,7 +10,7 @@ export const ProjectCardStatic: React.FC<ProjectCardProps> = ({ currentProject }
     <div
       className="block relative aspect-[16/10] rounded-2xl shadow-2xl group bg-[var(--bg-card)] border border-white/10 overflow-hidden"
       style={{
-        boxShadow: `0 40px 80px -20px ${currentProject.color}40`
+        boxShadow: `0 40px 80px -20px ${currentProject.surfaceTo ?? currentProject.color}40`
       }}
     >
       <div

--- a/src/index.css
+++ b/src/index.css
@@ -68,3 +68,31 @@ button {
   outline: 2px solid var(--accent-primary);
   outline-offset: 3px;
 }
+
+/* Hero ambient glow — color-typed custom properties so the radial-gradient tint
+   can cross-fade between projects (raw gradients aren't interpolable, which is
+   why the color used to snap). Values are set inline per active project in
+   Hero.tsx; the transition lives here so it can respect reduced-motion. */
+@property --hero-glow-main {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: transparent;
+}
+
+@property --hero-glow-accent {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: transparent;
+}
+
+.hero-ambient {
+  transition:
+    --hero-glow-main 700ms ease,
+    --hero-glow-accent 700ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-ambient {
+    transition: none;
+  }
+}

--- a/src/lib/color.ts
+++ b/src/lib/color.ts
@@ -1,0 +1,79 @@
+export interface Hsl {
+  h: number; // 0..360
+  s: number; // 0..1
+  l: number; // 0..1
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+export function hexToHsl(hex: string): Hsl {
+  let value = hex.replace('#', '').trim();
+  if (value.length === 3) {
+    value = value
+      .split('')
+      .map((char) => char + char)
+      .join('');
+  }
+
+  const r = parseInt(value.slice(0, 2), 16) / 255;
+  const g = parseInt(value.slice(2, 4), 16) / 255;
+  const b = parseInt(value.slice(4, 6), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const delta = max - min;
+
+  let h = 0;
+  if (delta !== 0) {
+    if (max === r) h = ((g - b) / delta) % 6;
+    else if (max === g) h = (b - r) / delta + 2;
+    else h = (r - g) / delta + 4;
+    h *= 60;
+    if (h < 0) h += 360;
+  }
+
+  const l = (max + min) / 2;
+  const s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+
+  return { h, s, l };
+}
+
+export function hslToHex({ h, s, l }: Hsl): string {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+
+  const [r, g, b] = [
+    [c, x, 0],
+    [x, c, 0],
+    [0, c, x],
+    [0, x, c],
+    [x, 0, c],
+    [c, 0, x]
+  ][Math.min(5, Math.floor(h / 60))];
+
+  const toHex = (channel: number) =>
+    Math.round((channel + m) * 255)
+      .toString(16)
+      .padStart(2, '0');
+
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+/**
+ * Turns a card surface color into a luminous "glow" tone for the hero ambient
+ * light. Lightness and saturation are clamped into a pleasant range so the glow
+ * always reads as vivid light over the dark background — even when the source
+ * surface is near-black. When the base is essentially grayscale, the hue is
+ * borrowed from `hueFallback` (the project accent) so the glow still has color.
+ */
+export function toGlow(base: string, hueFallback?: string): string {
+  const source = hexToHsl(base);
+  const hue = source.s < 0.18 && hueFallback ? hexToHsl(hueFallback).h : source.h;
+
+  return hslToHex({
+    h: hue,
+    s: clamp(Math.max(source.s, 0.35), 0, 0.8),
+    l: clamp(source.l, 0.46, 0.62)
+  });
+}


### PR DESCRIPTION
## Summary
The hero ambient glow now echoes the active card's own surface gradient instead of a standalone `color` field that often clashed with the card. Fixes the cases where a green glow sat behind a purple/magenta card.

## Problem
The hero background (`Hero.tsx`) and the featured card shadow (`ProjectCardStatic.tsx`) both used `project.color`. But the card's visible identity is its `surfaceFrom → surfaceTo` gradient. For several projects these diverged:
- **aurawall**: green `#347B66` glow behind a magenta `#C71459` card
- **imaginizim**: green glow behind a violet `#4E4279` card

## Change
- New `src/lib/color.ts` — `hexToHsl` / `hslToHex` / `toGlow`. `toGlow` normalizes a surface color into a luminous tone (clamps lightness 0.46–0.62 and saturation ≥0.35) so it always reads as vivid light over the dark `#0d1520` background, even when the source surface is near-black. Near-grayscale bases borrow the hue from a fallback.
- `Hero.tsx` — two glows derived from the active card: **main** (behind the card) from `surfaceTo`, **accent** (headline side) from `surfaceFrom` (hue falling back to `surfaceTo` when dark).
- `ProjectCardStatic.tsx` — card drop-shadow aligned to `surfaceTo`.

## Result (verified in the running app)
| project | before | after |
|---|---|---|
| aurawall | green | magenta/pink echoing the card |
| imaginizim | green | violet |
| nebula | cyan | magenta + blue, logo pops |
| sonara | bright cyan | subtle teal, matches the dark card |

All 10 projects stay cohesive. No new dependency — pure CSS gradients fed by computed colors.

## Verification
- ✅ `bun run lint` — clean, 0 warnings
- ✅ `bun run build` — tsc + vite build
- ✅ Screenshotted aurawall, imaginizim, nebula, sonara in the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)