### PR TITLE
docs: refresh README to match the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ Portfolio site for Matheus Pereira, built with React, Vite, TypeScript, Tailwind
 
 - React 19
 - TypeScript
-- Vite 7
+- Vite 8
 - Tailwind CSS v4
-- Framer Motion
 - i18next
 
 ## Development
@@ -51,8 +50,8 @@ npm run dev
 src/
   components/   UI sections and reusable cards
   data/         project metadata rendered on the page
-  hooks/        render and motion helpers
   layouts/      layout shell
+  lib/          color and helper utilities
   locales/      translations
   styles/       shared theme tokens
 public/


### PR DESCRIPTION
The README had a few stale facts (caught while reviewing the repo):

| Was | Now |
|---|---|
| Stack: Vite 7 | Vite 8 (matches `package.json` `^8.0.16`) |
| Stack: Framer Motion | removed — not a dependency |
| Structure: `src/hooks/` | removed — the folder doesn't exist |
| Structure: (missing `lib/`) | added — `src/lib/` (color utilities) |

Preview port `4300` is correct (`vite.config.ts`) and left as-is. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)