### PR TITLE
[codex] Add CodeQL and establish formatting baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,13 @@
 version: 2
 
 updates:
-  - package-ecosystem: "bun"
-    directory: "/"
+  - package-ecosystem: 'bun'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "tuesday"
-      time: "09:00"
-      timezone: "America/Sao_Paulo"
+      interval: 'weekly'
+      day: 'tuesday'
+      time: '09:00'
+      timezone: 'America/Sao_Paulo'
     open-pull-requests-limit: 5
     cooldown:
       default-days: 5
@@ -17,17 +17,17 @@ updates:
     groups:
       bun-minor-and-patch:
         patterns:
-          - "*"
+          - '*'
         update-types:
-          - "minor"
-          - "patch"
+          - 'minor'
+          - 'patch'
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "tuesday"
-      time: "09:30"
-      timezone: "America/Sao_Paulo"
+      interval: 'weekly'
+      day: 'tuesday'
+      time: '09:30'
+      timezone: 'America/Sao_Paulo'
     cooldown:
       default-days: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.3.13"
+          bun-version: '1.3.13'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '24 3 * * 2'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze JavaScript and TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          category: '/language:javascript-typescript'

--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -3,10 +3,10 @@ name: Dependency Guard
 on:
   pull_request:
     paths:
-      - "package.json"
-      - "bun.lock"
-      - ".github/dependabot.yml"
-      - ".github/workflows/**"
+      - 'package.json'
+      - 'bun.lock'
+      - '.github/dependabot.yml'
+      - '.github/workflows/**'
 
 permissions:
   contents: read
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.3.13"
+          bun-version: '1.3.13'
 
       - name: Install without lifecycle scripts
         run: bun install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
## O que mudou
- adiciona análise CodeQL para JavaScript/TypeScript em pushes, pull requests e execução semanal
- mantém permissões mínimas e fixa todas as GitHub Actions por SHA completo
- normaliza a formatação dos workflows e do Dependabot para estabelecer um baseline limpo do Prettier
- habilita Secret Scanning e Push Protection nas configurações do repositório

## Motivo
O repositório não tinha análise de code scanning configurada, o Secret Scanning estava desabilitado e o check global do Prettier falhava por formatação preexistente.

## Validação
- `bunx prettier --check .`
- `bun install --frozen-lockfile --ignore-scripts`
- `bun audit --audit-level=high`
- `bun run lint`
- `bun run type-check`
- `bun run build`
- `git diff --check`